### PR TITLE
fix request error handling

### DIFF
--- a/lib/edmunds/api.rb
+++ b/lib/edmunds/api.rb
@@ -21,8 +21,8 @@ module Edmunds
       def initialize(response)
         error = JSON.parse(response.body)
 
-        @error_type = error['error']['errorType']
-        @message = error['error']['message']
+        @error_type = error['errorType']
+        @message = error['message']
       end
     end
   end

--- a/test/fixtures/decode_full_invalid_vin.yml
+++ b/test/fixtures/decode_full_invalid_vin.yml
@@ -1,0 +1,48 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.edmunds.com/api/vehicle/v2/vins/invalid?api_key=EDMUNDS_API_KEY&fmt=json
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 400
+      message: Bad Request
+    headers:
+      Cache-Control:
+      - max-age=1200
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 12 Nov 2015 15:13:36 GMT
+      Server:
+      - Apache-Coyote/1.1
+      Set-Cookie:
+      - content-targeting=DE, NW, KOLN, , 50.93, 6.95, , vhigh, 5000, http
+      - device-characterization=, , false, false, , , ,
+      X-Akamai-Device-Characteristics:
+      - device_os=,device_os_version=,is_mobile=false,is_tablet=false,physical_screen_height=,physical_screen_width=,resolution_height=,resolution_width=
+      X-Akamai-Edgescape:
+      - georegion=85,country_code=DE,region_code=NW,city=KOLN,dma=,pmsa=,msa=,areacode=,county=,fips=,lat=50.93,long=6.95,timezone=GMT+1,zip=,continent=EU,throughput=vhigh,bw=5000,asnum=3320
+      X-Mashery-Responder:
+      - prod-j-worker-us-east-1e-105.mashery.com
+      Content-Length:
+      - '159'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"status":"BAD_REQUEST","errorType":"INCORRECT_PARAMS","message":"The
+        VIN is incorrect. It must be 17 characters","moreInfoUrl":"http://developer.edmunds.com"}'
+    http_version: 
+  recorded_at: Thu, 12 Nov 2015 15:13:37 GMT
+recorded_with: VCR 3.0.0

--- a/test/fixtures/decode_full_not_found.yml
+++ b/test/fixtures/decode_full_not_found.yml
@@ -1,0 +1,48 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.edmunds.com/api/vehicle/v2/vins/JHMAP00000T000000?api_key=EDMUNDS_API_KEY&fmt=json
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Cache-Control:
+      - max-age=1200
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 12 Nov 2015 15:08:05 GMT
+      Server:
+      - Apache-Coyote/1.1
+      Set-Cookie:
+      - content-targeting=DE, NW, KOLN, , 50.93, 6.95, , vhigh, 5000, http
+      - device-characterization=, , false, false, , , ,
+      X-Akamai-Device-Characteristics:
+      - device_os=,device_os_version=,is_mobile=false,is_tablet=false,physical_screen_height=,physical_screen_width=,resolution_height=,resolution_width=
+      X-Akamai-Edgescape:
+      - georegion=85,country_code=DE,region_code=NW,city=KOLN,dma=,pmsa=,msa=,areacode=,county=,fips=,lat=50.93,long=6.95,timezone=GMT+1,zip=,continent=EU,throughput=vhigh,bw=5000,asnum=3320
+      X-Mashery-Responder:
+      - prod-j-worker-us-east-1e-108.mashery.com
+      Content-Length:
+      - '148'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"status":"NOT_FOUND","errorType":"RESOURCE_NOT_FOUND","message":"Information
+        not found for this VIN.","moreInfoUrl":"http://developer.edmunds.com"}'
+    http_version: 
+  recorded_at: Thu, 12 Nov 2015 15:08:05 GMT
+recorded_with: VCR 3.0.0

--- a/test/vehicle/specification/vin_decoding_test.rb
+++ b/test/vehicle/specification/vin_decoding_test.rb
@@ -16,4 +16,26 @@ class DecodingVinTest < Minitest::Test
       assert_equal '24', full.mpg_highway
     end
   end
+
+  def test_full_invalid_vin
+    VCR.use_cassette('decode_full_invalid_vin') do
+      exception = assert_raises Edmunds::Api::Exception do
+        Edmunds::Vehicle::Specification::VinDecoding::Full.find('invalid')
+      end
+
+      assert_match "The VIN is incorrect. It must be 17 characters", exception.message
+      assert_match "INCORRECT_PARAMS", exception.error_type
+    end
+  end
+
+  def test_full_not_found
+    VCR.use_cassette('decode_full_not_found') do
+      exception = assert_raises Edmunds::Api::Exception do
+        Edmunds::Vehicle::Specification::VinDecoding::Full.find('JHMAP00000T000000')
+      end
+
+      assert_match "Information not found for this VIN.", exception.message
+      assert_match "RESOURCE_NOT_FOUND", exception.error_type
+    end
+  end
 end


### PR DESCRIPTION
- the `message` and `errorType` are not nested inside another `error` hash
- added VCR specs for VIN decoding error cases
