### PR TITLE
also extract `niceName` for make & model

### DIFF
--- a/lib/edmunds/vehicle/specification/make.rb
+++ b/lib/edmunds/vehicle/specification/make.rb
@@ -38,11 +38,12 @@ module Edmunds
         end
 
         class Make
-          attr_reader :id, :name, :models
+          attr_reader :id, :name, :nice_name, :models
 
           def initialize(attributes)
             @id = attributes['id']
             @name = attributes['name']
+            @nice_name = attributes['niceName']
             @models = attributes['models'].map { |json| Edmunds::Vehicle::Specification::Model::Model.new(json) } if attributes.key?('models')
           end
 

--- a/lib/edmunds/vehicle/specification/model.rb
+++ b/lib/edmunds/vehicle/specification/model.rb
@@ -8,11 +8,12 @@ module Edmunds
     module Specification
       module Model
         class Model
-          attr_reader :id, :name, :years
+          attr_reader :id, :name, :nice_name, :years
 
           def initialize(attributes)
             @id = attributes['id']
             @name = attributes['name']
+            @nice_name = attributes['niceName']
             @years = attributes['years'].map { |json| Edmunds::Vehicle::Specification::ModelYear::ModelYear.new(json) } if attributes.key?('years')
           end
 

--- a/test/vehicle/specification/make_test.rb
+++ b/test/vehicle/specification/make_test.rb
@@ -13,6 +13,7 @@ class MakeTest < Minitest::Test
       # Check that the fields are accessible by our model
       assert_equal 200_000_001, make.id
       assert_equal 'Audi', make.name
+      assert_equal 'audi', make.nice_name
       assert_equal 35, make.models.count
     end
   end

--- a/test/vehicle/specification/model_test.rb
+++ b/test/vehicle/specification/model_test.rb
@@ -13,6 +13,7 @@ class ModelTest < Minitest::Test
       # Check that the fields are accessible by our model
       assert_equal 'Honda_Accord', model.id
       assert_equal 'Accord', model.name
+      assert_equal 'accord', model.nice_name
       assert_equal 26, model.years.count
     end
   end


### PR DESCRIPTION
- this is important because they are used for other API endpoints, like `/api/vehicle/v2/:makeNiceName/:modelNiceName/:year/styles`
